### PR TITLE
Added three new settings for compact mode

### DIFF
--- a/engine/configdialog.cpp
+++ b/engine/configdialog.cpp
@@ -79,6 +79,9 @@ void ConfigDialog::updateSettings()
 
     config->setCompactStyle(m_generalPage->compactStyle());
     config->setMaxWidth(m_generalPage->maxWidth());
+    config->setFixedSize(m_generalPage->fixedSize());
+    config->setShowPlayPause(m_generalPage->showPlayPause());
+    config->setTrackInfoFormat(m_generalPage->trackInfoFormat());
     config->setExpandedStyle(m_generalPage->expandedStyle());
     config->setShowStop(m_generalPage->showStop());
     config->setShowSeekSlider(m_generalPage->showSeekSlider());

--- a/engine/generalconfig.ui
+++ b/engine/generalconfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>527</height>
+    <height>590</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -150,6 +150,56 @@
             </spacer>
            </item>
           </layout>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_TrackInfoFormat">
+          <property name="text">
+           <string>Track Info Format:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="kcfg_FixedSize">
+          <property name="text">
+           <string>Fixed Size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QComboBox" name="kcfg_TrackInfoFormat">
+          <item>
+           <property name="text">
+            <string>Default</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Artist - Track</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Track - Artist</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Track</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Track by Artist</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="kcfg_ShowPlayPause">
+          <property name="text">
+           <string>Show play/pause button</string>
+          </property>
          </widget>
         </item>
        </layout>

--- a/engine/generalwidget.h
+++ b/engine/generalwidget.h
@@ -42,6 +42,18 @@ public:
         return m_ui.kcfg_MaxWidth->value();
     }
 
+    inline int trackInfoFormat() const {
+        return m_ui.kcfg_TrackInfoFormat->currentIndex();
+    }
+
+    inline bool fixedSize() const {
+        return m_ui.kcfg_FixedSize->isChecked();
+    }
+
+    inline bool showPlayPause() const {
+        return m_ui.kcfg_ShowPlayPause->isChecked();
+    }
+
     inline int expandedStyle() const {
         return m_ui.kcfg_ExpandedStyle->currentIndex();
     }

--- a/engine/playbar.cpp
+++ b/engine/playbar.cpp
@@ -182,6 +182,9 @@ const DataEngine::Data &PlayBar::data()
 
     m_data->insert(QStringLiteral("CompactStyle"),     config->compactStyle());
     m_data->insert(QStringLiteral("MaxWidth"),         config->maxWidth());
+    m_data->insert(QStringLiteral("FixedSize"),        config->fixedSize());
+    m_data->insert(QStringLiteral("ShowPlayPause"),    config->showPlayPause());
+    m_data->insert(QStringLiteral("TrackInfoFormat"),  config->trackInfoFormat());
     m_data->insert(QStringLiteral("ExpandedStyle"),    config->expandedStyle());
     m_data->insert(QStringLiteral("ShowStop"),         config->showStop());
     m_data->insert(QStringLiteral("ShowVolumeSlider"), config->showVolumeSlider());

--- a/engine/playbar.kcfg
+++ b/engine/playbar.kcfg
@@ -21,6 +21,22 @@
           <entry name="MaxWidth" type="Int">
               <default>120</default>
           </entry>
+					<entry name="FixedSize" type="Bool">
+			   <default>false</default>
+          </entry>
+					<entry name="ShowPlayPause" type="Bool">
+			   <default>true</default>
+          </entry>
+			<entry name="TrackInfoFormat" type="Enum">
+              <choices>
+                  <choice name="Default"/>
+                  <choice name="ArtistTrack"/>
+                  <choice name="TrackArtist"/>
+                  <choice name="Track"/>
+									<choice name="TrackbyArtist"/>
+              </choices>
+              <default>0</default>
+		  </entry>
 		  <entry name="ExpandedStyle" type="Enum">
               <choices>
                   <choice name="Horizontal"/>

--- a/plasmoid/contents/ui/PlaybackBar.qml
+++ b/plasmoid/contents/ui/PlaybackBar.qml
@@ -22,7 +22,8 @@ import org.kde.plasma.core 2.0 as PlasmaCore
 PlaybackItem {
     id: playbackbar
 
-    visible: mpris2.sourceActive && (playbarEngine.compactStyle === playbar.playbackButtons)
+    visible: (mpris2.sourceActive || playbarEngine.fixedSize)
+    && (playbarEngine.compactStyle === playbar.playbackButtons)
 
     enabled: visible
 

--- a/plasmoid/contents/ui/SeekBar.qml
+++ b/plasmoid/contents/ui/SeekBar.qml
@@ -23,7 +23,8 @@ import org.kde.plasma.components 2.0 as PlasmaComponents
 PlaybackItem {
     id: seekBar
 
-    visible: mpris2.sourceActive && (playbarEngine.compactStyle === playbar.seekbar)
+    visible: (mpris2.sourceActive || playbarEngine.fixedSize)
+    && (playbarEngine.compactStyle === playbar.seekbar)
 
     enabled: visible
 
@@ -40,8 +41,9 @@ PlaybackItem {
         spacing: 0
 
         Item {
-            width: buttonSize.width
-            height: buttonSize.height
+            visible: playbarEngine.showPlayPause
+            width: visible ? buttonSize.width : 0
+            height: visible ? buttonSize.height : 0
 
             IconWidget {
                 id: button
@@ -71,8 +73,8 @@ PlaybackItem {
             value: 0
             stepSize: 1
             updateValueWhileDragging: true
-            visible: mpris2.playbackStatus !== 'Stopped' && slider.enabled
-            property int size: mpris2.playbackStatus === 'Stopped' || !slider.enabled ? 40 : playbarEngine.maxWidth
+            visible: (mpris2.playbackStatus !== 'Stopped' && slider.enabled) || playerEngine.fixedSize
+            property int size: !visible ? 40 : playbarEngine.maxWidth
 
             Behavior on size {
                 SequentialAnimation {
@@ -83,7 +85,7 @@ PlaybackItem {
                     ScriptAction {
                         script: setVisible()
                         function setVisible() {
-                            if (mpris2.playbackStatus !== 'Stopped' && slider.enabled)
+                            if ((mpris2.playbackStatus !== 'Stopped' && slider.enabled) || playerEngine.fixedSize)
                                 slider.visible = true
                         }
                     }
@@ -94,7 +96,8 @@ PlaybackItem {
                         script: setNotVisible()
                         function setNotVisible() {
                             if (mpris2.playbackStatus === 'Stopped' || slider.size <= 50 || !slider.enabled)
-                                slider.visible = false
+                                if (!playerEngine.fixedSize)
+                                    slider.visible = false
                         }
                     }
                 }

--- a/plasmoid/contents/ui/TrackInfoBar.qml
+++ b/plasmoid/contents/ui/TrackInfoBar.qml
@@ -25,7 +25,7 @@ import org.kde.plasma.components 2.0 as PlasmaComponents
 PlaybackItem {
     id: infoBar
 
-    visible: mpris2.sourceActive
+    visible: (mpris2.sourceActive || playbarEngine.fixedSize)
     && (playbarEngine.compactStyle === playbar.trackinfo)
 
     enabled: visible
@@ -47,8 +47,9 @@ PlaybackItem {
         flow: vertical ? Flow.TopToBottom : Flow.LeftToRight
 
         Item {
-            width: buttonSize.width
-            height: buttonSize.height
+            visible: playbarEngine.showPlayPause
+            width: visible ? buttonSize.width : 0
+            height: visible ? buttonSize.height : 0
 
             property alias iconSource: button.iconSource
 
@@ -73,7 +74,7 @@ PlaybackItem {
             height: vertical ? size : buttonSize.height
             clip: true
 
-            property int size: trackinfo.text ? playbarEngine.maxWidth : 0
+            property int size: (trackinfo.text || playbarEngine.fixedSize) ? playbarEngine.maxWidth : 0
 
             Behavior on size {
                 NumberAnimation {
@@ -100,8 +101,24 @@ PlaybackItem {
                 width: content.size
                 height: maxWidth
 
-                text: mpris2.title && mpris2.artist ? i18n('%1 <b>By</b> %2', mpris2.title, mpris2.artist)
-                        : (mpris2.title ? mpris2.title : '')
+                function getTrackInfo() {
+                  if (mpris2.title && mpris2.artist) {
+                    switch (playbarEngine.trackInfoFormat) {
+                    case playbar.formatDefault:
+                        return i18n('%1 <b>By</b> %2', mpris2.title, mpris2.artist);
+                    case playbar.trackByArtistLower:
+                        return i18n('%1 <b>by</b> %2', mpris2.title, mpris2.artist);
+                    case playbar.artistTrack:
+                        return mpris2.artist + ' <b>-</b> ' + mpris2.title;
+                    case playbar.trackArtist:
+                        return mpris2.title + ' <b>-</b> ' + mpris2.artist;
+                    }
+                  }
+
+                  return (mpris2.title ? mpris2.title : '');
+                }
+
+                text: getTrackInfo()
 
                 verticalAlignment: Text.AlignVCenter
                 wrapMode: scroll.scrolling ? Text.NoWrap : Text.WrapAnywhere

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -44,6 +44,15 @@ Item {
         readonly property int maxWidth: hasSource('MaxWidth')
         ? data[source]['MaxWidth'] : 120
 
+        readonly property bool fixedSize: hasSource('FixedSize')
+        ? data[source]['FixedSize'] : false
+
+        readonly property bool showPlayPause: hasSource('ShowPlayPause')
+        ? data[source]['ShowPlayPause'] : true
+
+        readonly property int trackInfoFormat: hasSource('TrackInfoFormat')
+        ? data[source]['TrackInfoFormat'] : playbar.formatDefault
+
         readonly property int expandedStyle: hasSource('ExpandedStyle')
         ? data[source]['ExpandedStyle'] : playbar.horizontalLayout
 
@@ -357,6 +366,14 @@ Item {
         readonly property int playbackButtons: 1
         readonly property int seekbar: 2
         readonly property int trackinfo: 3
+
+        // ENUM: TrackInfoFormat
+        readonly property int formatDefault: 0
+        readonly property int artistTrack: 1
+        readonly property int trackArtist: 2
+        readonly property int trackOnly: 3
+        readonly property int trackByArtistLower: 4
+
 
         // ENUM: ExpandedStyle
         readonly property int horizontalLayout: 0


### PR DESCRIPTION
I wanted these customisations on my system for _aesthetic_ purposes.

- Option to set fixed widget width (therefore not moving the entire row of other widgets when I close the music player).
- Option to hide Play/Pause button in track info and seek bar layouts.
- More track info format options (Track **-** Artist, Artist **-** Track, Track Only, Track **by** Artist (lowercase)).

Translations are needed for the new items in the settings menu and the lowercase 'by' track info format.